### PR TITLE
Update to latest enum tags syntax

### DIFF
--- a/nickel-mode.el
+++ b/nickel-mode.el
@@ -51,7 +51,7 @@
 
 
 (defconst nickel-mode-identifiers (rx symbol-start alpha (* (or alpha ?\_ ?\')) symbol-end))
-(defconst nickel-mode-enum-tags (rx symbol-start ?\` alpha (* (or alpha ?\_ ?\')) symbol-end))
+(defconst nickel-mode-enum-tags (rx symbol-start ?\' alpha (* (or alpha ?\_ ?\')) symbol-end))
 (defconst nickel-mode-numbers (rx symbol-start (optional ?\-) (+ digit) (optional ?\. (+ digit)) symbol-end))
 (defconst nickel-mode-operators
   (regexp-opt


### PR DESCRIPTION
Adapt to latest upstream, which changed the enum tag syntax to use a single quote as prefix instead of a backtick (https://github.com/tweag/nickel/pull/1279)