### PR TITLE
[Meta] Change copyright owner to Modus

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Tweag I/O Limited.
+Copyright (c) Modus Create LLC and its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Tweag has been acquired in 2022 by Modus Create. This PR updates the various licenses to reflect this change legally.